### PR TITLE
Don't allow empty protein ids for a pdb file

### DIFF
--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -1015,6 +1015,7 @@ struct MResidueID
 
 MProtein::MProtein()
   : mResidueCount(0)
+  , mID("unknown")
   , mChainBreaks(0)
   , mIgnoredWaterMolecules(0)
   , mNrOfHBondsInParallelBridges(0)


### PR DESCRIPTION
When a pdb file is made of atom lines only and the pdbid is missing, then mkhssp makes an alignment with an empty string as query id. hsspconv can't handle that.

This fix replaces that empty string by the name "unknown", which hsspconv CAN handle.