### PR TITLE
read amino acids after the TER record

### DIFF
--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -1172,10 +1172,6 @@ void MProtein::ReadPDB(std::istream& is, bool cAlphaOnly)
       continue;
     }
 
-    // add ATOMs only if the chain isn't terminated
-    if (terminatedChains.count(line[21]))
-      continue;
-
     if (ba::starts_with(line, "TER   "))
     {
       if (atoms.empty())


### PR DESCRIPTION
Gert Requested this change after the following dssp entries appeared empty:

4erl
3npn
3owi
3npq
3oxe
3oxm
3oww
3owz
3oxj
4erl
5kvj