### PR TITLE
fix compile on macos and make libzeep optional

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -32,7 +32,7 @@ AX_BOOST_SYSTEM
 AX_BOOST_THREAD
 AX_BOOST_UNIT_TEST_FRAMEWORK
 AM_CONDITIONAL([HAVE_CPPCHECK], [test -n "$CPPCHECK"])
-AC_CHECK_LIB([zeep], [main], [ ],
+AC_CHECK_LIB([zeep], [main],,
              [AC_MSG_WARN([libzeep not found - cannot build mkhssp])])
 AX_CHECK_LIBRARY([LIBBZ2], [bzlib.h], [bz2], [],
                  [AC_MSG_WARN([libbz2 not found - compressed files not supported])])

--- a/src/dssp.cpp
+++ b/src/dssp.cpp
@@ -77,7 +77,7 @@ std::string ResidueToDSSPLine(const MResidue& residue)
 
   double alpha;
   char chirality;
-  std::tr1::tie(alpha,chirality) = residue.Alpha();
+  std::tie(alpha,chirality) = residue.Alpha();
 
   uint32 bp[2] = {};
   char bridgelabel[2] = { ' ', ' ' };

--- a/src/fetchdbrefs.cpp
+++ b/src/fetchdbrefs.cpp
@@ -1,3 +1,5 @@
+#ifdef HAVE_LIBZEEP
+
 #include "fetchdbrefs.h"
 
 #include "mas.h"
@@ -307,4 +309,7 @@ void FetchPDBReferences(const std::string& inBaseURL, const std::string& inDb,
   {
 
   }
+
 }
+
+#endif

--- a/src/hssp-nt.cpp
+++ b/src/hssp-nt.cpp
@@ -23,7 +23,7 @@
 #include <boost/lexical_cast.hpp>
 #include <boost/range/adaptor/sliced.hpp>
 #include <boost/regex.hpp>
-#include <boost/tr1/cmath.hpp>
+#include <cmath>
 
 #include <algorithm>
 #include <cmath>
@@ -474,7 +474,7 @@ void MProfile::AdjustXGapCosts(std::vector<float>& gop,
     {
       if (ix + d >= m_residues.size() or
         m_residues[ix + d].m_dist[22] > 0 or
-        ix - d < 0 or
+        ix < d or
         m_residues[ix - d].m_dist[22] > 0)
       {
         gop[ix] *= (2 + ((8 - d) * 2)) / 8.f;

--- a/src/mas.h
+++ b/src/mas.h
@@ -40,10 +40,6 @@ typedef uint32_t  uint32;
 typedef int64_t    int64;
 typedef uint64_t  uint64;
 
-#ifndef nullptr
-#define nullptr NULL
-#endif
-
 // we even have globals:
 extern int VERBOSE;
 

--- a/src/primitives-3d.cpp
+++ b/src/primitives-3d.cpp
@@ -152,7 +152,7 @@ double CosinusAngle(const MPoint& p1, const MPoint& p2, const MPoint& p3, const 
 
 // --------------------------------------------------------------------
 
-std::tr1::tuple<double,MPoint> QuaternionToAngleAxis(MQuaternion q)
+std::tuple<double,MPoint> QuaternionToAngleAxis(MQuaternion q)
 {
   if (q.R_component_1() > 1)
     q = Normalize(q);
@@ -168,7 +168,7 @@ std::tr1::tuple<double,MPoint> QuaternionToAngleAxis(MQuaternion q)
 
   MPoint axis(q.R_component_2() / s, q.R_component_3() / s, q.R_component_4() / s);
 
-  return std::tr1::make_tuple(angle, axis);
+  return std::make_tuple(angle, axis);
 }
 
 MPoint CenterPoints(std::vector<MPoint>& points)

--- a/src/primitives-3d.h
+++ b/src/primitives-3d.h
@@ -12,7 +12,6 @@
 #pragma once
 
 #include <boost/math/quaternion.hpp>
-#include <boost/tr1/tuple.hpp>
 
 #include <vector>
 
@@ -71,7 +70,7 @@ double CosinusAngle(const MPoint& p1, const MPoint& p2, const MPoint& p3,
 
 MQuaternion Normalize(MQuaternion q);
 
-std::tr1::tuple<double,MPoint> QuaternionToAngleAxis(MQuaternion q);
+std::tuple<double,MPoint> QuaternionToAngleAxis(MQuaternion q);
 MPoint Centroid(std::vector<MPoint>& points);
 MPoint CenterPoints(std::vector<MPoint>& points);
 MQuaternion AlignPoints(const std::vector<MPoint>& a,

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -35,7 +35,7 @@ using boost::optional;
 // --------------------------------------------------------------------
 
 const double
-  kSSBridgeDistance = 3.0,
+//  kSSBridgeDistance = 3.0,
   kMinimalDistance = 0.5,
   kMinimalCADistance = 9.0,
   kMinHBondEnergy = -9.9,
@@ -554,7 +554,7 @@ double MResidue::Psi() const
   return result;
 }
 
-std::tr1::tuple<double,char> MResidue::Alpha() const
+std::tuple<double,char> MResidue::Alpha() const
 {
   double alhpa = 360;
   char chirality = ' ';
@@ -571,7 +571,7 @@ std::tr1::tuple<double,char> MResidue::Alpha() const
     else
       chirality = '+';
   }
-  return std::tr1::make_tuple(alhpa, chirality);
+  return std::make_tuple(alhpa, chirality);
 }
 
 double MResidue::Kappa() const

--- a/src/structure.h
+++ b/src/structure.h
@@ -171,7 +171,7 @@ class MResidue
 
   double        Phi() const;
   double        Psi() const;
-  std::tr1::tuple<double,char>
+  std::tuple<double,char>
             Alpha() const;
   double        Kappa() const;
   double        TCO() const;


### PR DESCRIPTION
This PR fixes a few minor issues when trying to compile xssp on MacOS 10.13 (High Sierra).