### PR TITLE
Minor changes required for building inside a CentOS docker image

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -7,7 +7,7 @@ shared_LDADD =	$(BOOST_DATE_TIME_LIB) \
 								$(BOOST_REGEX_LIB) \
 								$(BOOST_SYSTEM_LIB) \
 								$(BOOST_THREAD_LIB) \
-								-lpthread
+								-lpthread -lrt
 
 mkdssp_SOURCES	=	src/dssp.cpp \
 									src/dssp.h \

--- a/src/mkhssp.cpp
+++ b/src/mkhssp.cpp
@@ -14,6 +14,8 @@
 #include "structure.h"
 #include "utils.h"
 
+#include <iostream>
+
 #include <boost/algorithm/string.hpp>
 #include <boost/filesystem/fstream.hpp>
 #include <boost/foreach.hpp>


### PR DESCRIPTION
For whatever reason, I had to make minor changes in order to build `xssp` inside a CentOS docker image.

- Build logs without this patch: https://gitlab.com/ostrokach-forge/xssp/-/jobs/165628588
- Build logs with this patch: https://gitlab.com/ostrokach-forge/xssp/-/jobs/165621286

I also had to amend `CPPFLAGS` as follows, which I would not generally have to do for other packages.

```bash
export CPPFLAGS="${CPPFLAGS} -I${PREFIX}/include -Wno-sign-compare"`
```

Thanks!