### PR TITLE
Remove the std::swap function.

### DIFF
--- a/src/hssp-convert-3to1.cpp
+++ b/src/hssp-convert-3to1.cpp
@@ -582,15 +582,6 @@ void seq::validate(const seq& qseq)
         boost::format("validation failed for %1%") % m_impl->m_id);
 }
 
-namespace std
-{
-  template<>
-  void swap(seq& a, seq& b)
-  {
-    a.swap(b);
-  }
-}
-
 // --------------------------------------------------------------------
 
 struct ResidueInfo


### PR DESCRIPTION
This function is already implemented in c++11. No need to have it here.